### PR TITLE
Fix layout to adhere to HTML5 schema

### DIFF
--- a/layouts/shortcodes/home-projects.html
+++ b/layouts/shortcodes/home-projects.html
@@ -56,7 +56,9 @@
         {{ end }}
       {{ end }}
       {{if gt (len ($.Scratch.GetSortedMapValues "wg_projects")) 4}}
+        <li class="padding-0">
         <div class="collapse" id="featured-more-projects" aria-expanded="true" style="">
+        <ul class="list-inline">
           {{ range after 4 ($.Scratch.GetSortedMapValues "wg_projects") }}
             {{ if not (in $highlights .project_id) }}
             <li class="col-xs-12 col-sm-8 col-md-6 ">
@@ -77,7 +79,9 @@
             </li>
             {{ end }}
           {{ end }}
+          </ul>
         </div>
+        </li>
       {{ end }}
     </ul>
   </div>

--- a/less/styles.less
+++ b/less/styles.less
@@ -129,7 +129,7 @@ section#wg-projects {
     & {
       padding: 10px;
     }
-    & > div > a { 
+    & > div:not(#featured-more-projects) > a { 
       position: absolute; 
       bottom: 20px; 
       margin-left: auto;
@@ -137,12 +137,19 @@ section#wg-projects {
       left: 20px; 
       right: 20px;
     }
-    & > div { 
+    & > div:not(#featured-more-projects) { 
       border: 1px solid #f0f0f2;
       padding:10px;
       padding-bottom: 50px;
       background-color: #fff;
     }
+    // required to override inline-list padding
+    &.padding-0 {
+      padding: 0;
+    }
+  }
+  #featured-more-projects ul {
+  	margin-left:0px;
   }
 }
 


### PR DESCRIPTION
Fixes the projects layout to have only li children within the ul elements.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>