### PR TITLE
Switched to nginx:stable-alpine-for-hugo parent docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_IMAGE_TAG=stable-alpine
+ARG NGINX_IMAGE_TAG=stable-alpine-for-hugo
 
 FROM debian:10-slim AS builder
 


### PR DESCRIPTION
nginx:stable-alpine-for-hugo uses 404 from hugo  template

Fix issue #41 

Signed-off-by: Mikael Barbero <mikael.barbero@eclipse-foundation.org>