### PR TITLE
Issue #119: Updates to the Community page

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,7 +1,5 @@
 ---
 title: "Community"
-headline: "Get Involved"
-tagline: ECD Tools is a community of members, adopters, developers, and other contributors. Join us!
 date: 2020-09-30T14:53:00+02:00
 hide_page_title: true
 hide_sidebar: true
@@ -9,28 +7,37 @@ hide_sidebar: true
 
 ## Open Source and Open Collaboration
 
-[Eclipse Cloud Development Tools](https://ecdtools.eclipse.org) (ECD Tools) is a community of members, adopters, developers, and other contributors that collaborate to define, promote and implement Web and Cloud-based development tools and drive the evolution and broad adoption of these tools.
+The [Eclipse Cloud DevTools Working Group](https://ecdtools.eclipse.org) is a community of members, adopters, developers, and other contributors that collaborate to define, promote and implement Web and Cloud-based development tools and drive the evolution and broad adoption of these tools.
 
-The ECD Tools working group is a vendor-neutral community made up of Eclipse Foundation members that wish to freely collaborate on new technology development in the Cloud Dev Tools space.
+We are a vendor-neutral community made up of Eclipse Foundation members that wish to freely collaborate on new technology development in the Cloud Dev Tools space.
 
 Membership in the working group brings many [benefits](https://www.eclipse.org/org/workinggroups/), including joint marketing initiatives and direct access to a community of skilled and dedicated open source developers.
 
-You will find below ways to get involved.
+Even if you are not a member, there are many ways to get involved. Join us!
 
 ## Communication Channels
 
 ### Mailing lists
 
-We use mailing lists for all official communications. They are freely accessible but you need an Eclipse.org account to be able to subscribe to them.
+We use mailing lists for all official communications. They are freely accessible but you need an [Eclipse.org account](https://accounts.eclipse.org/) to be able to subscribe to them.
 
-* [ECD Tools working group list](https://accounts.eclipse.org/mailing-list/ecd-tools-wg)
-* [ECD Tools Project Management Committee (PMC) list](https://accounts.eclipse.org/mailing-list/ecd-pmc)
+* [Eclipse Cloud DevTools working group list](https://accounts.eclipse.org/mailing-list/ecd-tools-wg)
+* [Eclipse Cloud Development Project Management Committee (PMC) list](https://accounts.eclipse.org/mailing-list/ecd-pmc)
 
-Most ECD Tools projects also have their own mailing list. You will find them on [this page](https://accounts.eclipse.org/mailing-list/).
+All Eclipse Cloud DevTools projects also have their own mailing list. You will find them on [this page](https://accounts.eclipse.org/mailing-list/).
 
 ### IM
 
-For instant messaging, we use Slack and you can join at [ecd-tools.slack.com](https://join.slack.com/t/ecd-tools/shared_invite/zt-htempyhj-s8eWWUdEbvLYmiGPjc_WXQ).
+For instant messaging, we use Slack and you can join at [ecd-tools.slack.com](https://join.slack.com/t/ecd-tools/shared_invite/zt-p7kzp2xd-gYgjefEYE7wvqsKBjKZWMg).
+
+#### Project Channels
+
+Several Eclipse Cloud DevTools projects have their own real-time communication channels.
+
+* Eclipse Che: Che engineers hang out on [Mattermost](https://mattermost.eclipse.org/eclipse/channels/eclipse-che)
+* Eclipse Dirigible: This project has a [Slack workspace](https://eclipse-dirigible.slack.com/)
+* Eclipse JKube : [Gitter](https://gitter.im/eclipse/jkube)
+* Eclipse Open VSX: [Gitter](https://gitter.im/eclipse/openvsx)
 
 ### Social Media
 
@@ -45,30 +52,36 @@ Some ideas to amplify our message.
 
 ## Calendar
 
-All ECD Tools calls and events are managed through a single shared Google calendar.
+All Eclipse Cloud DevTools calls and events are managed through a single shared Google calendar.
 
 ### Formats
 
 * [Web version](https://calendar.google.com/calendar/embed?src=c_atlvn0hqrerh0bnr4ag25tpm8g%40group.calendar.google.com&ctz=Europe%2FDublin) - Use the + in the bottom right to add it to your calendar 
 * [iCal format](https://calendar.google.com/calendar/ical/c_atlvn0hqrerh0bnr4ag25tpm8g%40group.calendar.google.com/public/basic.ics) - compatible with most other calendar clients
 
-## Calls
+## Virtual Meetups and Events
 
 ### Community Calls
 
-We hold a call for our community regularly. The aim of this call is to discuss upcoming events, ongoing initiatives and give projects the opportunity to share updates with the community.
+We hold a call for our community quarterly. The aim of this call is to give projects the opportunity to share updates with the community, discuss upcoming events, and to share and get feedback on ongoing initiatives.
 
 We use a publicly available document to manage the meeting's [agenda](https://docs.google.com/document/d/1w9QSdgxqyI81CbN8Jnrsq_DgmOT6Lsy19bD6UUtmBR4/edit?usp=sharing). You can add items to it anytime, we just ask you leave your name and a way to follow up about it before the event.
 
-### Project Calls
+#### Project Calls
 
-Several ECD Tools projects hold calls to keep in touch with their communities. Please consider attending if you leverage one of the projects below or are just curious about them.
+Several Eclipse Cloud DevTools projects hold calls to keep in touch with their communities. Please consider attending if you leverage one of the projects below or are just curious about them.
 
 * [Eclipse Che](https://github.com/eclipse/che/wiki/Che-Dev-Meetings): These calls are meant for Che adopters and contributors to chat about some project development details (can be planning, concerns, or more technical details). The goal is to better synchronize and organize efforts of the various contributors in order to make Che better.
 * [Eclipse Theia Dev Meetings](https://github.com/eclipse-theia/theia/wiki/Dev-Meetings): Developers and everyone interested meet to discuss anything related to the development of Theia.
 
-## Virtual ECD Tools Meetups and Events
+### Cloud Tool Time
 
-Our virtual Webinar Series is coming soon.
+Our Cloud Tool Time virtual webinars are managed through our [Meetup.com Virtual Eclipse Community Meetup](https://www.meetup.com/Virtual-Eclipse-Community-MeetUp/). To propose a topic, whether to present yourself or just to suggest, please [fill out this form](https://forms.gle/KJQ7T3a3V5NZPLEdA).
 
-To propose a topic for a virtual event, whether to present yourself or just to suggest, please [fill out this form](https://forms.gle/KJQ7T3a3V5NZPLEdA). Virtual meetups are managed through our [Meetup.com Virtual Eclipse Community Meetup](https://www.meetup.com/Virtual-Eclipse-Community-MeetUp/).
+### Cloud Chat
+
+We are running an interview series to showcase our projects and technologies and the people who build them. The audience is anyone interested in cloud development tools, in particular developers and potential adopters of the software. To propose a guest, or to request to be a guest, please [fill out this form](https://forms.gle/p4B7qmT6FuaGVaev5).
+
+### Recordings
+
+Recordings for our events, along with other content, are available on [our playlist at the Eclispe Foundation YouTube channel](https://www.youtube.com/playlist?list=PLy7t4z5SYNaQi-Tg57o1b3iYmxCxHxY0C).


### PR DESCRIPTION
Changes include:

- Layout: Removing the jumbotron header, as the content needs to be front and center
- Adding information about project IM channels
- More information about our events
- Changing to new 'Eclipse Cloud DevTools' terminology throughout


Signed-off-by: Brian King <brian.king@eclipse-foundation.org>